### PR TITLE
Support all configuration options, add install instructions

### DIFF
--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -1,3 +1,11 @@
 # openstack-cloud-controller-manager
 
 Helm Chart for OpenStack Cloud Controller Manager
+
+## Unsupported configurations
+
+* The chart does not support the use of a custom `clouds.yaml` file. Therefore, the following config values can’t be set for the `[Global]` section:
+  * `use-clouds`
+  * `clouds-file`
+  * `cloud`
+* The chart currently does not support the specification of custom `LoadBalancerClass`es.

--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -1,11 +1,32 @@
 # openstack-cloud-controller-manager
 
-Helm Chart for OpenStack Cloud Controller Manager
+Deploys the OpenStack Cloud Controller Manager to your cluster
+
+## How To install
+
+You need to configure an `openstack-ccm.yaml` values file with at least:
+
+- `cloudConfig.global.authUrl` with the Keystone URL
+- Authentication
+  - with password: `cloudConfig.global.username` and `cloudconfig.global.password`
+  - with application credentials: (`cloudConfig.global.applicationCredentialId` or `cloudConfig.global.applicationCredentialName`) and `cloudConfig.global.applicationCredentialSecret`
+- Load balancing
+  - `cloudConfig.loadbalancer.floatingNetworkId` **or**
+  - `cloudConfig.loadbalancer.floatingSubnetId` **or**
+  - `cloudConfig.loadbalancer.floatingSubnet`
+
+Then run:
+
+```
+helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
+helm repo update
+helm install openstack-ccm cpo/openstack-cloud-controller-manager --values openstac-ccm.yaml
+```
 
 ## Unsupported configurations
 
-* The chart does not support the use of a custom `clouds.yaml` file. Therefore, the following config values can’t be set for the `[Global]` section:
-  * `use-clouds`
-  * `clouds-file`
-  * `cloud`
-* The chart currently does not support the specification of custom `LoadBalancerClass`es.
+- The chart does not support the use of a custom `clouds.yaml` file. Therefore, the following config values can’t be set for the `[Global]` section:
+  - `use-clouds`
+  - `clouds-file`
+  - `cloud`
+- The chart currently does not support the specification of custom `LoadBalancerClass`es.

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -50,22 +50,56 @@ Create cloud-config makro.
 */}}
 {{- define "cloudConfig" -}}
 [Global]
-auth-url    = {{ .Values.cloudConfig.global.authUrl }}
-username    = {{ .Values.cloudConfig.global.username }}
-password    = {{ .Values.cloudConfig.global.password }}
-tenant-name = {{ .Values.cloudConfig.global.tenantName }}
-domain-name = {{ .Values.cloudConfig.global.domainName }}
-region      = {{ .Values.cloudConfig.global.region }}
+auth-url                      = {{ .Values.cloudConfig.global.authUrl }}
+os-endpoint-type              = {{ .Values.cloudConfig.global.osEndpointType }}
+ca-file                       = {{ .Values.cloudConfig.global.caFile }}
+cert-file                     = {{ .Values.cloudConfig.global.certFile }}
+key-file                      = {{ .Values.cloudConfig.global.keyFile }}
+username                      = {{ .Values.cloudConfig.global.username }}
+password                      = {{ .Values.cloudConfig.global.password }}
+region                        = {{ .Values.cloudConfig.global.region }}
+domain-id                     = {{ .Values.cloudConfig.global.domainId }}
+domain-name                   = {{ .Values.cloudConfig.global.domainName }}
+tenant-id                     = {{ .Values.cloudConfig.global.tenantId }}
+tenant-name                   = {{ .Values.cloudConfig.global.tenantName }}
+tenant-domain-id              = {{ .Values.cloudConfig.global.tenantDomainId }}
+tenant-domain-name            = {{ .Values.cloudConfig.global.tenantDomainName }}
+user-domain-id                = {{ .Values.cloudConfig.global.userDomainId }}
+user-domain-name              = {{ .Values.cloudConfig.global.userDomainName }}
+trust-id                      = {{ .Values.cloudConfig.global.trustId }}
+trustee-id                    = {{ .Values.cloudConfig.global.trusteeId }}
+use-clouds                    = false
+application-credential-id     = {{ .Values.cloudConfig.global.applicationCredentialId }}
+application-credential-name   = {{ .Values.cloudConfig.global.applicationCredentialName }}
+application-credential-secret = {{ .Values.cloudConfig.global.applicationCredentialSecret }}
+tls-insecure                  = {{ .Values.cloudConfig.global.tlsInsecure }}
+
+[Networking]
+ipv6-support-disabled = {{ .Values.cloudConfig.networking.ipv6SupportDisabled }}
+public-network-name   = {{ .Values.cloudConfig.networking.publicNetworkName }}
+internal-network-name = {{ .Values.cloudConfig.networking.internalNetworkName }}
 
 [LoadBalancer]
-subnet-id           = {{ .Values.cloudConfig.loadbalancer.subnetId }}
-floating-network-id = {{ .Values.cloudConfig.loadbalancer.floatingNetworkId }}
-create-monitor      = {{ .Values.cloudConfig.loadbalancer.createMonitor }}
-monitor-delay       = {{ .Values.cloudConfig.loadbalancer.monitorDelay }}
-monitor-timeout     = {{ .Values.cloudConfig.loadbalancer.monitorTimeout }}
-monitor-max-retries = {{ .Values.cloudConfig.loadbalancer.monitorMaxRetries }}
-use-octavia         = {{ .Values.cloudConfig.loadbalancer.useOctavia  }}
-lb-provider         = {{ .Values.cloudConfig.loadbalancer.lbProvider  }}
+use-octavia             = {{ .Values.cloudConfig.loadbalancer.useOctavia  }}
+floating-network-id     = {{ .Values.cloudConfig.loadbalancer.floatingNetworkId }}
+floating-subnet-id      = {{ .Values.cloudConfig.loadbalancer.floatingSubnetId }}
+floating-subnet         = {{ .Values.cloudConfig.loadbalancer.floatingSubnet }}
+floating-subnet-tags    = {{ .Values.cloudConfig.loadbalancer.floatingSubnetTags }}
+lb-method               = {{ .Values.cloudConfig.loadbalancer.lbMethod }}
+lb-provider             = {{ .Values.cloudConfig.loadbalancer.lbProvider }}
+lb-version              = {{ .Values.cloudConfig.loadbalancer.lbVersion }}
+subnet-id               = {{ .Values.cloudConfig.loadbalancer.subnetId }}
+network-id              = {{ .Values.cloudConfig.loadbalancer.networkId }}
+manage-security-groups  = {{ .Values.cloudConfig.loadbalancer.manageSecurityGroups }}
+create-monitor          = {{ .Values.cloudConfig.loadbalancer.createMonitor }}
+monitor-delay           = {{ .Values.cloudConfig.loadbalancer.monitorDelay }}
+monitor-max-retries     = {{ .Values.cloudConfig.loadbalancer.monitorMaxRetries }}
+monitor-timeout         = {{ .Values.cloudConfig.loadbalancer.monitorTimeout }}
+internal-lb             = {{ .Values.cloudConfig.loadbalancer.internalLb }}
+cascade-delete          = {{ .Values.cloudConfig.loadbalancer.cascadeDelete }}
+flavor-id               = {{ .Values.cloudConfig.loadbalancer.flavorId }}
+availability-zone       = {{ .Values.cloudConfig.loadbalancer.availabilityZone }}
+enable-ingress-hostname = {{ .Values.cloudConfig.loadbalancer.enableIngressHostname }}
 
 [Metadata]
 search-order = {{ .Values.cloudConfig.metadata.searchOrder }}

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -67,9 +67,6 @@ monitor-max-retries = {{ .Values.cloudConfig.loadbalancer.monitorMaxRetries }}
 use-octavia         = {{ .Values.cloudConfig.loadbalancer.useOctavia  }}
 lb-provider         = {{ .Values.cloudConfig.loadbalancer.lbProvider  }}
 
-[BlockStorage]
-ignore-volume-az = {{ .Values.cloudConfig.blockstorage.ignoreVolumeAz }}
-
 [Metadata]
 search-order = {{ .Values.cloudConfig.metadata.searchOrder }}
 {{- end -}}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -69,8 +69,6 @@ cloudConfig:
     monitorTimeout: 10s
     monitorMaxRetries: 3
     useOctavia: false
-    lbProvider: vlb
-  blockstorage:
-    ignoreVolumeAz: false
+    lbProvider:
   metadata:
     searchOrder: metadataService,configDrive

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -55,20 +55,54 @@ secret:
 
 cloudConfig:
   global:
-    authUrl:
-    region:
-    username:
-    password:
-    tenantName:
-    domainName:
+    authUrl: ""
+    osEndpointType: ""
+    caFile: ""
+    certFile: ""
+    keyFile: ""
+    username: ""
+    password: ""
+    region: ""
+    domainId: ""
+    domainName: ""
+    tenantId: ""
+    tenantName: ""
+    tenantDomainId: ""
+    tenantDomainName: ""
+    userDomainId: ""
+    userDomainName: ""
+    trustId: ""
+    trusteeId: ""
+    applicationCredentialId: ""
+    applicationCredentialName: ""
+    applicationCredentialSecret: ""
+
+  networking:
+    ipv6SupportDisabled: false
+    publicNetworkName: ""
+    internalNetworkName: ""
+
   loadbalancer:
-    subnetId:
-    floatingNetworkId:
-    createMonitor: true
+    useOctavia: true
+    floatingNetworkId: ""
+    floatingSubnetId: ""
+    floatingSubnet: ""
+    floatingSubnetTags: ""
+    lbMethod: ""
+    lbProvider: ""
+    lbVersion: ""
+    subnetId: ""
+    networkId: ""
+    manageSecurityGroups: false
+    createMonitor: false
     monitorDelay: 5s
-    monitorTimeout: 10s
-    monitorMaxRetries: 3
-    useOctavia: false
-    lbProvider:
+    monitorMaxRetries: 1
+    monitorTimeout: 3s
+    internalLb: false
+    cascadeDelete: true
+    flavorId: ""
+    availabilityZone: ""
+    enableIngressHostname: ""
+
   metadata:
     searchOrder: metadataService,configDrive


### PR DESCRIPTION
This PR:

* enables support for all configuration options (and sets the defaults to the ones described in [the configuration instructions](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager)
* updates already set default values to the defaults of the ccm
* adds install instructions 