### PR TITLE
Simplify configuration with default values

### DIFF
--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -1,32 +1,35 @@
 # openstack-cloud-controller-manager
 
-Deploys the OpenStack Cloud Controller Manager to your cluster
+Deploys the OpenStack Cloud Controller Manager to your cluster.
+
+Default configuration values are the same as the CCM itself.
 
 ## How To install
 
 You need to configure an `openstack-ccm.yaml` values file with at least:
 
-- `cloudConfig.global.authUrl` with the Keystone URL
+- `cloudConfig.global.auth-url` with the Keystone URL
 - Authentication
   - with password: `cloudConfig.global.username` and `cloudconfig.global.password`
-  - with application credentials: (`cloudConfig.global.applicationCredentialId` or `cloudConfig.global.applicationCredentialName`) and `cloudConfig.global.applicationCredentialSecret`
+  - with application credentials: (`cloudConfig.global.application-credential-id` or `cloudConfig.global.application-credential-name`) and `cloudConfig.global.application-credential-secret`
 - Load balancing
-  - `cloudConfig.loadbalancer.floatingNetworkId` **or**
-  - `cloudConfig.loadbalancer.floatingSubnetId` **or**
-  - `cloudConfig.loadbalancer.floatingSubnet`
+  - `cloudConfig.loadbalancer.floating-network-id` **or**
+  - `cloudConfig.loadbalancer.floating-subnet-id` **or**
+  - `cloudConfig.loadbalancer.floating-subnet`
+
+If you want to enable health checks for your Load Balancers (optional), set `cloudConfig.loadbalancer.create-monitor: true`.
 
 Then run:
 
 ```
 helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
 helm repo update
-helm install openstack-ccm cpo/openstack-cloud-controller-manager --values openstac-ccm.yaml
+helm install openstack-ccm cpo/openstack-cloud-controller-manager --values openstack-ccm.yaml
 ```
 
 ## Unsupported configurations
 
-- The chart does not support the use of a custom `clouds.yaml` file. Therefore, the following config values can’t be set for the `[Global]` section:
+- The chart does not support the mounting of custom `clouds.yaml` files. Therefore, the following config values in the `[Global]` section won’t have any effect:
   - `use-clouds`
   - `clouds-file`
   - `cloud`
-- The chart currently does not support the specification of custom `LoadBalancerClass`es.

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -64,6 +64,11 @@ Create cloud-config makro.
 {{ $key }} = {{ $value }}
 {{- end }}
 
+[BlockStorage]
+{{- range $key, $value := .Values.cloudConfig.blockStorage }}
+{{ $key }} = {{ $value }}
+{{- end }}
+
 [Metadata]
 {{- range $key, $value := .Values.cloudConfig.metadata }}
 {{ $key }} = {{ $value }}

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -50,57 +50,22 @@ Create cloud-config makro.
 */}}
 {{- define "cloudConfig" -}}
 [Global]
-auth-url                      = {{ .Values.cloudConfig.global.authUrl }}
-os-endpoint-type              = {{ .Values.cloudConfig.global.osEndpointType }}
-ca-file                       = {{ .Values.cloudConfig.global.caFile }}
-cert-file                     = {{ .Values.cloudConfig.global.certFile }}
-key-file                      = {{ .Values.cloudConfig.global.keyFile }}
-username                      = {{ .Values.cloudConfig.global.username }}
-password                      = {{ .Values.cloudConfig.global.password }}
-region                        = {{ .Values.cloudConfig.global.region }}
-domain-id                     = {{ .Values.cloudConfig.global.domainId }}
-domain-name                   = {{ .Values.cloudConfig.global.domainName }}
-tenant-id                     = {{ .Values.cloudConfig.global.tenantId }}
-tenant-name                   = {{ .Values.cloudConfig.global.tenantName }}
-tenant-domain-id              = {{ .Values.cloudConfig.global.tenantDomainId }}
-tenant-domain-name            = {{ .Values.cloudConfig.global.tenantDomainName }}
-user-domain-id                = {{ .Values.cloudConfig.global.userDomainId }}
-user-domain-name              = {{ .Values.cloudConfig.global.userDomainName }}
-trust-id                      = {{ .Values.cloudConfig.global.trustId }}
-trustee-id                    = {{ .Values.cloudConfig.global.trusteeId }}
-use-clouds                    = false
-application-credential-id     = {{ .Values.cloudConfig.global.applicationCredentialId }}
-application-credential-name   = {{ .Values.cloudConfig.global.applicationCredentialName }}
-application-credential-secret = {{ .Values.cloudConfig.global.applicationCredentialSecret }}
-tls-insecure                  = {{ .Values.cloudConfig.global.tlsInsecure }}
+{{- range $key, $value := .Values.cloudConfig.global }}
+{{ $key }} = {{ $value }}
+{{- end }}
 
 [Networking]
-ipv6-support-disabled = {{ .Values.cloudConfig.networking.ipv6SupportDisabled }}
-public-network-name   = {{ .Values.cloudConfig.networking.publicNetworkName }}
-internal-network-name = {{ .Values.cloudConfig.networking.internalNetworkName }}
+{{- range $key, $value := .Values.cloudConfig.networking }}
+{{ $key }} = {{ $value }}
+{{- end }}
 
 [LoadBalancer]
-use-octavia             = {{ .Values.cloudConfig.loadbalancer.useOctavia  }}
-floating-network-id     = {{ .Values.cloudConfig.loadbalancer.floatingNetworkId }}
-floating-subnet-id      = {{ .Values.cloudConfig.loadbalancer.floatingSubnetId }}
-floating-subnet         = {{ .Values.cloudConfig.loadbalancer.floatingSubnet }}
-floating-subnet-tags    = {{ .Values.cloudConfig.loadbalancer.floatingSubnetTags }}
-lb-method               = {{ .Values.cloudConfig.loadbalancer.lbMethod }}
-lb-provider             = {{ .Values.cloudConfig.loadbalancer.lbProvider }}
-lb-version              = {{ .Values.cloudConfig.loadbalancer.lbVersion }}
-subnet-id               = {{ .Values.cloudConfig.loadbalancer.subnetId }}
-network-id              = {{ .Values.cloudConfig.loadbalancer.networkId }}
-manage-security-groups  = {{ .Values.cloudConfig.loadbalancer.manageSecurityGroups }}
-create-monitor          = {{ .Values.cloudConfig.loadbalancer.createMonitor }}
-monitor-delay           = {{ .Values.cloudConfig.loadbalancer.monitorDelay }}
-monitor-max-retries     = {{ .Values.cloudConfig.loadbalancer.monitorMaxRetries }}
-monitor-timeout         = {{ .Values.cloudConfig.loadbalancer.monitorTimeout }}
-internal-lb             = {{ .Values.cloudConfig.loadbalancer.internalLb }}
-cascade-delete          = {{ .Values.cloudConfig.loadbalancer.cascadeDelete }}
-flavor-id               = {{ .Values.cloudConfig.loadbalancer.flavorId }}
-availability-zone       = {{ .Values.cloudConfig.loadbalancer.availabilityZone }}
-enable-ingress-hostname = {{ .Values.cloudConfig.loadbalancer.enableIngressHostname }}
+{{- range $key, $value := .Values.cloudConfig.loadBalancer }}
+{{ $key }} = {{ $value }}
+{{- end }}
 
 [Metadata]
-search-order = {{ .Values.cloudConfig.metadata.searchOrder }}
-{{- end -}}
+{{- range $key, $value := .Values.cloudConfig.metadata }}
+{{ $key }} = {{ $value }}
+{{- end }}
+{{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -53,56 +53,9 @@ secret:
   create: true
 #  name:
 
+# Specify settings with the same key as the CCM config: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
 cloudConfig:
   global:
-    authUrl: ""
-    osEndpointType: ""
-    caFile: ""
-    certFile: ""
-    keyFile: ""
-    username: ""
-    password: ""
-    region: ""
-    domainId: ""
-    domainName: ""
-    tenantId: ""
-    tenantName: ""
-    tenantDomainId: ""
-    tenantDomainName: ""
-    userDomainId: ""
-    userDomainName: ""
-    trustId: ""
-    trusteeId: ""
-    applicationCredentialId: ""
-    applicationCredentialName: ""
-    applicationCredentialSecret: ""
-
   networking:
-    ipv6SupportDisabled: false
-    publicNetworkName: ""
-    internalNetworkName: ""
-
-  loadbalancer:
-    useOctavia: true
-    floatingNetworkId: ""
-    floatingSubnetId: ""
-    floatingSubnet: ""
-    floatingSubnetTags: ""
-    lbMethod: ""
-    lbProvider: ""
-    lbVersion: ""
-    subnetId: ""
-    networkId: ""
-    manageSecurityGroups: false
-    createMonitor: false
-    monitorDelay: 5s
-    monitorMaxRetries: 1
-    monitorTimeout: 3s
-    internalLb: false
-    cascadeDelete: true
-    flavorId: ""
-    availabilityZone: ""
-    enableIngressHostname: ""
-
+  loadBalancer:
   metadata:
-    searchOrder: metadataService,configDrive

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -58,4 +58,5 @@ cloudConfig:
   global:
   networking:
   loadBalancer:
+  blockStorage:
   metadata:


### PR DESCRIPTION
This PR simplifies the configuration. By only specifying the sections as maps, users can use the same keys for settings as in the config file which are then written directly to the cloud.conf.

This only deploys the necessary settings to the file and prevents problems with values set to an empty string.